### PR TITLE
Fix devcontainer startup loop                   

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,8 +8,7 @@
     "forwardPorts": [5052, 5432],
 
     "containerEnv": {
-        "SHELL": "/bin/bash",
-        "DOCKER_API_VERSION": "1.43"
+        "SHELL": "/bin/bash"
     },
 
     "customizations": {
@@ -50,9 +49,5 @@
         }
     },
     
-    "remoteUser": "vscode",
-    "features": {
-        // Enable the docker CLI to interact with other containers (e.g. the postgres db)
-        "ghcr.io/devcontainers/features/docker-outside-of-docker:1.6.5": {}
-    }
+    "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,7 +45,6 @@
                 "sqltools.completionLanguages": ["sql", "sql-snowflake", "sql-postgres"]
             },
             "extensions": [
-                "innoverio.vscode-dbt-power-user",
                 "ms-python.python",
                 "ms-python.debugpy",
                 "samuelcolvin.jinjahtml",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,10 +25,6 @@
                     "**/macros/**/*.sql": "jinja-sql",
                     "**/tests/**/*.sql": "jinja-sql"
                 },
-                // Configure formatter for the dbt files
-                "[jinja-sql]": {
-                    "editor.defaultFormatter": "innoverio.vscode-dbt-power-user"
-                },
                 "sqltools.connections": [
                     {
                         "previewLimit": 50,

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # main dev container
   app:
@@ -10,7 +8,8 @@ services:
       - ../..:/workspaces:cached
     command: sleep infinity
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   db:
     image: postgres:17
@@ -19,7 +18,12 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
-    volumes: 
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    volumes:
       - postgres-data:/var/lib/postgresql/data
       # SQL files mounted to /docker-entrypoint-initdb.d/ are executed when the container first launches.
       # We use it to populate the tpch schema and tables (with a tiny bit of data).
@@ -31,18 +35,17 @@ services:
     restart: unless-stopped
     environment:
       PGADMIN_DEFAULT_EMAIL: admin@example.com
-      PGADMIN_DEFAULT_PASSWORD: i_dont_think_this_password_is_ever_needed
-      PGADMIN_CONFIG_SERVER_MODE: 'False'  # Skip login screen
-      PGADMIN_CONFIG_PROXY_X_HOST_COUNT: 1  # Needed in Codespaces, see https://github.com/orgs/community/discussions/17918#discussioncomment-3005294 
+      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_CONFIG_SERVER_MODE: 'False'
+      PGADMIN_CONFIG_PROXY_X_HOST_COUNT: 1
       PGADMIN_CONFIG_PROXY_X_PREFIX_COUNT: 1
     volumes:
-      # Mount server config to auto-populate the connection list
-      # Only the password (postgres) will need to be entered
       - ./servers.json:/pgadmin4/servers.json
     ports:
       - "5052:80"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
 volumes:
   postgres-data:


### PR DESCRIPTION
## Description             
Removes the `dbt-power-user` VS Code extension which was causing infinite startup loops when no dbt project exists in the repository.
